### PR TITLE
Handles NSNull event values

### DIFF
--- a/src/ios/CDVTagManager.m
+++ b/src/ios/CDVTagManager.m
@@ -73,7 +73,12 @@
     NSString        *category = [command.arguments objectAtIndex:0];
     NSString        *eventAction = [command.arguments objectAtIndex:1];
     NSString        *eventLabel = [command.arguments objectAtIndex:2];
-    NSNumber        *eventValue = [NSNumber numberWithInt:[[command.arguments objectAtIndex:3] intValue]];
+    NSNumber *eventValue = @0;
+    id valueObject = [command.arguments objectAtIndex:3];
+    if (![valueObject isEqual:[NSNull null]])
+    {
+        eventValue = [NSNumber numberWithInt:[valueObject intValue]];
+    }
     
     if (inited)
     {


### PR DESCRIPTION
Hi !

I just ran into a bug when using angulartics along with your plugin. It does not broadcast events when the event value was not set in angulartics as the object in the array is `NSNull`. I added a check here to send `0` if none is available. Do you think this should be the expected behavior or would you like to send something else ? It's a quick pull request and I'd really appreciate it if you could take a look at it and possibly merge it as it prevents the reception of events on GA for one of my apps.

Cheers and thanks for the great plugin !
