### PR TITLE
fixing deprecated cordova method on ios

### DIFF
--- a/src/ios/CDVTagManager.m
+++ b/src/ios/CDVTagManager.m
@@ -135,7 +135,7 @@
 {
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:message];
     
-    [self writeJavascript:[commandResult toSuccessCallbackString:callbackID]];
+    [self.commandDelegate sendPluginResult:commandResult callbackId:callbackID];
 }
 
 -(void) failWithMessage:(NSString *)message toID:(NSString *)callbackID withError:(NSError *)error
@@ -143,7 +143,7 @@
     NSString        *errorMessage = (error) ? [NSString stringWithFormat:@"%@ - %@", message, [error localizedDescription]] : message;
     CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:errorMessage];
     
-    [self writeJavascript:[commandResult toErrorCallbackString:callbackID]];
+    [self.commandDelegate sendPluginResult:commandResult callbackId:callbackID];
 }
 
 -(void)dealloc


### PR DESCRIPTION
I was not able to compile your plugin on cordova ios@4.x.x
As reported in the issue https://github.com/kraihn/cordova-plugin-tag-manager/issues/24
